### PR TITLE
Deleted spaces in choices to work in new VS Code

### DIFF
--- a/snippets/classMethodSupport.json
+++ b/snippets/classMethodSupport.json
@@ -3,7 +3,7 @@
   "scope": "javascript,typescript,st",
   "prefix": ["method, no return"],
   "body": [
-      "${1|METHOD PUBLIC,METHOD PRIVATE,METHOD PROTECTED|} ${2:MyMethod}",
+      "METHOD ${1|PUBLIC,PRIVATE,PROTECTED|} ${2:MyMethod}",
       "\t$0;",
       "END_METHOD"
   ],
@@ -13,7 +13,7 @@
   "scope": "javascript,typescript,st",
   "prefix": ["method, with return"],
   "body": [
-      "${1|METHOD PUBLIC,METHOD PRIVATE,METHOD PROTECTED|} ${2:MyMethod} : ${3|BOOL,INT,LREAL,WORD,REAL,DINT,UINT,SINT|}",
+      "METHOD ${1|PUBLIC,PRIVATE,PROTECTED|} ${2:MyMethod} : ${3|BOOL,INT,LREAL,WORD,REAL,DINT,UINT,SINT|}",
 	  "\t${2:MyMethod} := $0;",
       "END_METHOD"
   ],

--- a/snippets/varSectionsClassSupport.json
+++ b/snippets/varSectionsClassSupport.json
@@ -2,7 +2,7 @@
   "VarSectionsClassSupport": {
     "prefix": ["var_ for classes"],
     "body": [
-      "${1|VAR PRIVATE,VAR PROTECTED,VAR PUBLIC|}",
+      "VAR ${1|PRIVATE,PROTECTED,PUBLIC|}",
       "\t$2",
       "END_VAR$0"
     ],


### PR DESCRIPTION
I deleted the spaces in the choices (dropdown-menues) of the snippets because they somehow did not work anymore with the newer version of VS Code / AX Code.